### PR TITLE
run install.sh with bash instead of default shell

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test": "tape ./tests",
-    "install": "./install.sh"
+    "install": "bash ./install.sh"
   },
   "devDependencies": {
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
not all shells support [[ style string comparison
http://stackoverflow.com/questions/12230690/string-comparison-in-bash-not-found