### PR TITLE
Change the BPM string value encoding from Latin1 to UTF8

### DIFF
--- a/src/taglib2.cc
+++ b/src/taglib2.cc
@@ -290,7 +290,7 @@ NAN_METHOD(readTagsSync) {
 
   if (map.contains("BPM")) {
     TagLib::String sl = map["BPM"].toString("");
-    TagLib::ByteVector vec = sl.data(TagLib::String::Latin1);
+    TagLib::ByteVector vec = sl.data(TagLib::String::UTF8);
     char* s = vec.data();
 
     obj->Set(
@@ -338,7 +338,7 @@ NAN_METHOD(readTagsSync) {
     int picIndex = 0;
 
     for (auto& p : tag->pictures()) {
-  
+
       v8::Local<v8::Object> imgObj = Nan::New<v8::Object>();
 
       auto data = p.second[0].data();


### PR DESCRIPTION
Fixes the issue with reading the BPM tag and getting a different integer value every time. 

Related to https://github.com/voltraco/node-taglib2/issues/5.